### PR TITLE
Android Studio 3 & Gradle 4 updates

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -19,14 +19,13 @@ allprojects {
 apply plugin: 'com.android.library'
 
 dependencies {
-    compile 'com.klinkerapps:logger:1.0.3'
-    compile 'com.squareup.okhttp:okhttp:2.5.0'
-    compile 'com.squareup.okhttp:okhttp-urlconnection:2.5.0'
+    implementation 'com.klinkerapps:logger:1.0.3'
+    implementation 'com.squareup.okhttp:okhttp:2.5.0'
+    implementation 'com.squareup.okhttp:okhttp-urlconnection:2.5.0'
 }
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.0"
 
     defaultConfig {
         minSdkVersion 21


### PR DESCRIPTION
updated to gradle 4.4 and converted all deprecated `compile` commands to `implementation` as recommended.